### PR TITLE
FEAT: Logger

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "googletest"]
 	path = googletest
 	url = https://github.com/google/googletest.git
+[submodule "spdlog"]
+	path = spdlog
+	url = https://github.com/gabime/spdlog.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ project(simulator)
 
 option(BUILD_PROJECT "Build tests" ON)
 
+include_directories(${CMAKE_SOURCE_DIR}/spdlog/include/)
 if (BUILD_PROJECT)
-    include_directories(${CMAKE_SOURCE_DIR}/spdlog/include/)
     set(TARGET_NAME "${PROJECT_NAME}")
     file(GLOB_RECURSE src "source/*.cpp")
     add_executable(${TARGET_NAME} main.cpp ${src})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ project(simulator)
 option(BUILD_PROJECT "Build tests" ON)
 
 if (BUILD_PROJECT)
+    include_directories(${CMAKE_SOURCE_DIR}/spdlog/include/)
     set(TARGET_NAME "${PROJECT_NAME}")
     file(GLOB_RECURSE src "source/*.cpp")
     add_executable(${TARGET_NAME} main.cpp ${src})

--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 
 # Build, test and run project
 
+Project uses Git submodules to manage dependencies. To initialize submodules run this command:
+```bash
+git submodule update --init --recursive
+```
+
 `CmakeFileLists.txt` have two options: `BUILD_MAIN` and `BUILD_TEST` (both are enabled by default). First one controles building of main executable `simulator`, second one - building tests for it (`test_simulator`).
 
-It is assumed that build files locates in `build` directory. You may do it the way you wish, but using `launch.json`, `tasks.json` and others from `.vscode_template` is recomended. 
+It is assumed that build files locates in `build` directory. You may do it the way you wish, but using `launch.json`, `tasks.json` and others from `.vscode_template` is recommended. 
 
 # Git hooks
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
-#include <iostream>
+#include <spdlog/spdlog.h>
 
 int main() {
-    std::cout << "Hello, world!" << std::endl;
+    spdlog::info("Hello, World!");
+
     return 0;
 }


### PR DESCRIPTION
Closes #97 

Add [spdlog](https://github.com/gabime/spdlog) logger as git submodule. It is a header-only version of spdlog.

[Examples of usage](https://github.com/gabime/spdlog/blob/v1.x/example/example.cpp).

To add a submodule you just need to run the following command:
`git submodule update --init --recursive`.

Then build project as usual:
```bash
mkdir build && cd build
cmake -DCMAKE_BUILD_TYPE=Release ..
cmake --build .
```