### PR TITLE
FEAT: implement identifiers for all entities

### DIFF
--- a/source/device/receiver.cpp
+++ b/source/device/receiver.cpp
@@ -3,10 +3,13 @@
 #include "event.hpp"
 #include "link.hpp"
 #include "logger/logger.hpp"
+#include "utils/identifier_factory.hpp"
 
 namespace sim {
 
-Receiver::Receiver() : m_router(std::make_unique<RoutingModule>()) {}
+Receiver::Receiver()
+    : m_router(std::make_unique<RoutingModule>()),
+      m_id(IdentifierFactory::get_instance().generate_id()) {}
 
 bool Receiver::add_inlink(std::shared_ptr<ILink> link) {
     if (link == nullptr) {
@@ -139,5 +142,7 @@ Time Receiver::send_ack(Packet data_packet) {
 std::set<std::shared_ptr<ILink>> Receiver::get_outlinks() const {
     return m_router->get_outlinks();
 }
+
+Id Receiver::get_id() const { return m_id; }
 
 }  // namespace sim

--- a/source/device/receiver.hpp
+++ b/source/device/receiver.hpp
@@ -3,12 +3,15 @@
 
 #include "packet.hpp"
 #include "routing_module.hpp"
+#include "utils/identifier_factory.hpp"
 
 namespace sim {
 
 struct Packet;
 
-class IReceiver : public IRoutingDevice, public IProcessingDevice {
+class IReceiver : public IRoutingDevice,
+                  public IProcessingDevice,
+                  public Identifiable {
 public:
     virtual ~IReceiver() = default;
 };
@@ -37,9 +40,12 @@ public:
     // The iterator over ingress buffers is stored in m_next_link.
     Time process() final;
 
+    Id get_id() const;
+
 private:
     Time send_ack(Packet data_packet);
     std::unique_ptr<RoutingModule> m_router;
+    Id m_id;
 };
 
 }  // namespace sim

--- a/source/device/receiver.hpp
+++ b/source/device/receiver.hpp
@@ -40,7 +40,7 @@ public:
     // The iterator over ingress buffers is stored in m_next_link.
     Time process() final;
 
-    Id get_id() const;
+    Id get_id() const final;
 
 private:
     Time send_ack(Packet data_packet);

--- a/source/device/sender.cpp
+++ b/source/device/sender.cpp
@@ -6,7 +6,9 @@
 
 namespace sim {
 
-Sender::Sender() : m_router(std::make_unique<RoutingModule>()) {}
+Sender::Sender()
+    : m_router(std::make_unique<RoutingModule>()),
+      m_id(IdentifierFactory::get_instance().generate_id()) {}
 
 bool Sender::add_inlink(std::shared_ptr<ILink> link) {
     if (link == nullptr) {
@@ -151,5 +153,7 @@ Time Sender::send_data() {
 std::set<std::shared_ptr<ILink>> Sender::get_outlinks() const {
     return m_router->get_outlinks();
 }
+
+Id Sender::get_id() const { return m_id; }
 
 }  // namespace sim

--- a/source/device/sender.hpp
+++ b/source/device/sender.hpp
@@ -2,12 +2,15 @@
 #include <queue>
 
 #include "device.hpp"
+#include "utils/identifier_factory.hpp"
 
 namespace sim {
 
 struct Packet;
 
-class ISender : public IRoutingDevice, public IProcessingDevice {
+class ISender : public IRoutingDevice,
+                public IProcessingDevice,
+                public Identifiable {
 public:
     virtual ~ISender() = default;
     virtual void enqueue_packet(Packet packet) = 0;
@@ -40,10 +43,13 @@ public:
     Time send_data() final;
 
     void enqueue_packet(Packet packet) final;
+    
+    Id get_id() const;
 
 private:
     std::queue<Packet> m_flow_buffer;
     std::unique_ptr<IRoutingDevice> m_router;
+    Id m_id;
 };
 
 }  // namespace sim

--- a/source/device/sender.hpp
+++ b/source/device/sender.hpp
@@ -44,7 +44,7 @@ public:
 
     void enqueue_packet(Packet packet) final;
     
-    Id get_id() const;
+    Id get_id() const final;
 
 private:
     std::queue<Packet> m_flow_buffer;

--- a/source/device/switch.cpp
+++ b/source/device/switch.cpp
@@ -7,7 +7,9 @@
 
 namespace sim {
 
-Switch::Switch() : m_router(std::make_unique<RoutingModule>()) {}
+Switch::Switch()
+    : m_router(std::make_unique<RoutingModule>()),
+      m_id(IdentifierFactory::get_instance().generate_id()) {}
 
 bool Switch::add_inlink(std::shared_ptr<ILink> link) {
     if (link == nullptr) {
@@ -98,5 +100,7 @@ Time Switch::process() {
 std::set<std::shared_ptr<ILink>> Switch::get_outlinks() const {
     return m_router->get_outlinks();
 }
+
+Id Switch::get_id() const { return m_id; }
 
 }  // namespace sim

--- a/source/device/switch.hpp
+++ b/source/device/switch.hpp
@@ -3,10 +3,13 @@
 #include <memory>
 
 #include "routing_module.hpp"
+#include "utils/identifier_factory.hpp"
 
 namespace sim {
 
-class ISwitch : public IRoutingDevice, public IProcessingDevice {
+class ISwitch : public IRoutingDevice,
+                public IProcessingDevice,
+                public Identifiable {
 public:
     virtual ~ISwitch() = default;
 };
@@ -31,9 +34,12 @@ public:
     // Packets are taken from ingress buffers on a round-robin basis.
     // The iterator over ingress buffers is stored in m_next_link.
     Time process() final;
+    
+    Id get_id() const;
 
 private:
     std::unique_ptr<RoutingModule> m_router;
+    Id m_id;
 };
 
 }  // namespace sim

--- a/source/device/switch.hpp
+++ b/source/device/switch.hpp
@@ -35,7 +35,7 @@ public:
     // The iterator over ingress buffers is stored in m_next_link.
     Time process() final;
     
-    Id get_id() const;
+    Id get_id() const final;
 
 private:
     std::unique_ptr<RoutingModule> m_router;

--- a/source/flow.cpp
+++ b/source/flow.cpp
@@ -15,7 +15,8 @@ Flow::Flow(std::shared_ptr<ISender> a_src, std::shared_ptr<IReceiver> a_dest,
       m_packet_size(a_packet_size),
       m_delay_between_packets(a_delay_between_packets),
       m_updates_number(0),
-      m_packets_to_send(a_packets_to_send) {}
+      m_packets_to_send(a_packets_to_send),
+      m_id(IdentifierFactory::get_instance().generate_id()) {}
 
 void Flow::schedule_packet_generation(Time time) {
     auto generate_event_ptr =
@@ -49,5 +50,7 @@ Time Flow::try_to_generate() {
 std::shared_ptr<ISender> Flow::get_sender() const { return m_src; }
 
 std::shared_ptr<IReceiver> Flow::get_receiver() const { return m_dest; }
+
+Id Flow::get_id() const { return m_id; }
 
 }  // namespace sim

--- a/source/flow.hpp
+++ b/source/flow.hpp
@@ -45,7 +45,7 @@ public:
     std::shared_ptr<ISender> get_sender() const final;
     std::shared_ptr<IReceiver> get_receiver() const final;
 
-    Id get_id() const;
+    Id get_id() const final;
 
 private:
     void schedule_packet_generation(Time time);

--- a/source/flow.hpp
+++ b/source/flow.hpp
@@ -3,13 +3,14 @@
 
 #include "device/receiver.hpp"
 #include "device/sender.hpp"
+#include "utils/identifier_factory.hpp"
 
 namespace sim {
 
 class IReceiver;
 class ISender;
 
-class IFlow {
+class IFlow : public Identifiable {
 public:
     virtual void start(Time time) = 0;
     virtual Time try_to_generate() = 0;
@@ -44,6 +45,8 @@ public:
     std::shared_ptr<ISender> get_sender() const final;
     std::shared_ptr<IReceiver> get_receiver() const final;
 
+    Id get_id() const;
+
 private:
     void schedule_packet_generation(Time time);
     void generate_packet();
@@ -54,6 +57,7 @@ private:
     Time m_delay_between_packets;
     std::uint32_t m_updates_number;
     std::uint32_t m_packets_to_send;
+    Id m_id;
 };
 
 }  // namespace sim

--- a/source/link.cpp
+++ b/source/link.cpp
@@ -1,7 +1,9 @@
 #include "link.hpp"
-#include "logger/logger.hpp"
+
 #include "event.hpp"
+#include "logger/logger.hpp"
 #include "scheduler.hpp"
+#include "utils/identifier_factory.hpp"
 
 namespace sim {
 
@@ -12,7 +14,8 @@ Link::Link(std::weak_ptr<IRoutingDevice> a_from,
       m_to(a_to),
       m_speed_mbps(a_speed_mbps),
       m_src_egress_delay(0),
-      m_transmission_delay(a_delay) {
+      m_transmission_delay(a_delay),
+      m_id(IdentifierFactory::get_instance().generate_id()) {
     if (a_from.expired() || a_to.expired()) {
         LOG_WARN("Passed link to device is expired");
     } else if (a_speed_mbps == 0) {
@@ -84,5 +87,7 @@ std::shared_ptr<IRoutingDevice> Link::get_to() const {
 
     return m_to.lock();
 };
+
+Id Link::get_id() const { return m_id; }
 
 }  // namespace sim

--- a/source/link.hpp
+++ b/source/link.hpp
@@ -57,7 +57,7 @@ public:
     std::shared_ptr<IRoutingDevice> get_from() const final;
     std::shared_ptr<IRoutingDevice> get_to() const final;
 
-    Id get_id() const;
+    Id get_id() const final;
 
 private:
     Time get_transmission_time(const Packet& packet) const;

--- a/source/link.hpp
+++ b/source/link.hpp
@@ -5,6 +5,7 @@
 #include <queue>
 
 #include "packet.hpp"
+#include "utils/identifier_factory.hpp"
 
 namespace sim {
 
@@ -13,7 +14,7 @@ class RoutingModule;
 /**
  * Unidirectional link from the source to a_next
  */
-class ILink {
+class ILink : public Identifiable {
 public:
     virtual ~ILink() = default;
 
@@ -56,6 +57,8 @@ public:
     std::shared_ptr<IRoutingDevice> get_from() const final;
     std::shared_ptr<IRoutingDevice> get_to() const final;
 
+    Id get_id() const;
+
 private:
     Time get_transmission_time(const Packet& packet) const;
 
@@ -64,6 +67,7 @@ private:
     std::uint32_t m_speed_mbps;
     Time m_src_egress_delay;
     Time m_transmission_delay;
+    Id m_id;
 
     // Queue at the ingress port of the m_next device
     std::queue<Packet> m_next_ingress;

--- a/source/types.hpp
+++ b/source/types.hpp
@@ -3,3 +3,4 @@
 // nanoseconds
 typedef std::uint32_t Time;
 typedef std::uint32_t Size;
+typedef std::uint32_t Id;

--- a/source/utils/identifier_factory.cpp
+++ b/source/utils/identifier_factory.cpp
@@ -1,0 +1,7 @@
+#include "identifier_factory.hpp"
+
+namespace sim {
+
+Id IdentifierFactory::generate_id() { return next_id++; }
+
+}  // namespace sim

--- a/source/utils/identifier_factory.hpp
+++ b/source/utils/identifier_factory.hpp
@@ -23,6 +23,7 @@ private:
 
 class Identifiable {
 public:
+    virtual ~Identifiable() = default;
     virtual Id get_id() const = 0;
 };
 

--- a/source/utils/identifier_factory.hpp
+++ b/source/utils/identifier_factory.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "types.hpp"
+
+namespace sim {
+
+class IdentifierFactory {
+public:
+    static IdentifierFactory& get_instance() {
+        static IdentifierFactory instance;
+        return instance;
+    }
+
+    Id generate_id();
+
+private:
+    IdentifierFactory() {}
+    IdentifierFactory(const IdentifierFactory&) = delete;
+    IdentifierFactory& operator=(const IdentifierFactory&) = delete;
+
+    Id next_id = 0;
+};
+
+class Identifiable {
+public:
+    virtual Id get_id() const = 0;
+};
+
+}  // namespace sim

--- a/test/device/utils.cpp
+++ b/test/device/utils.cpp
@@ -24,4 +24,6 @@ std::optional<sim::Packet> TestLink::get_packet() { return {packet}; };
 std::shared_ptr<sim::IRoutingDevice> TestLink::get_from() const { return src; };
 std::shared_ptr<sim::IRoutingDevice> TestLink::get_to() const { return dst; };
 
+Id TestLink::get_id() const { return 42; }
+
 }  // namespace test

--- a/test/device/utils.hpp
+++ b/test/device/utils.hpp
@@ -26,6 +26,8 @@ public:
     std::shared_ptr<sim::IRoutingDevice> get_from() const final;
     std::shared_ptr<sim::IRoutingDevice> get_to() const final;
 
+    Id get_id() const;
+
 private:
     std::shared_ptr<sim::IRoutingDevice> src;
     std::shared_ptr<sim::IRoutingDevice> dst;

--- a/test/device/utils.hpp
+++ b/test/device/utils.hpp
@@ -26,7 +26,7 @@ public:
     std::shared_ptr<sim::IRoutingDevice> get_from() const final;
     std::shared_ptr<sim::IRoutingDevice> get_to() const final;
 
-    Id get_id() const;
+    Id get_id() const final;
 
 private:
     std::shared_ptr<sim::IRoutingDevice> src;

--- a/test/identifier_factory_test.cpp
+++ b/test/identifier_factory_test.cpp
@@ -1,0 +1,45 @@
+#include "utils/identifier_factory.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+
+#include "device/device.hpp"
+
+namespace test {
+
+class TestIdentifierFactory : public testing::Test {
+public:
+    void TearDown() override {}
+    void SetUp() override {}
+};
+
+class Entity final : public sim::Identifiable {
+public:
+    Entity() : m_id(sim::IdentifierFactory::get_instance().generate_id()) {}
+    Id get_id() const final { return m_id; }
+
+private:
+    Id m_id;
+};
+
+TEST_F(TestIdentifierFactory, TestUniqueness) {
+    constexpr std::uint32_t ENTITIES_NUMBER = 10;
+    std::vector<std::unique_ptr<sim::Identifiable>> entities(ENTITIES_NUMBER);
+
+    std::generate(entities.begin(), entities.end(),
+                  [] { return std::make_unique<Entity>(); });
+
+    std::set<Id> ids;
+    std::transform(entities.begin(), entities.end(),
+                   std::inserter(ids, ids.begin()),
+                   [](auto& e) { return e->get_id(); });
+
+    ASSERT_EQ(ids.size(), ENTITIES_NUMBER);
+
+    Entity e{};
+    ASSERT_TRUE(!ids.contains(e.get_id()));
+}
+
+}  // namespace test

--- a/test/identifier_factory_test.cpp
+++ b/test/identifier_factory_test.cpp
@@ -26,15 +26,15 @@ private:
 
 TEST_F(TestIdentifierFactory, TestUniqueness) {
     constexpr std::uint32_t ENTITIES_NUMBER = 10;
-    std::vector<std::unique_ptr<sim::Identifiable>> entities(ENTITIES_NUMBER);
+    std::vector<Entity> entities(ENTITIES_NUMBER);
 
     std::generate(entities.begin(), entities.end(),
-                  [] { return std::make_unique<Entity>(); });
+                  [] { return Entity(); });
 
     std::set<Id> ids;
     std::transform(entities.begin(), entities.end(),
                    std::inserter(ids, ids.begin()),
-                   [](auto& e) { return e->get_id(); });
+                   [](auto& e) { return e.get_id(); });
 
     ASSERT_EQ(ids.size(), ENTITIES_NUMBER);
 

--- a/test/switch/flow_mock.cpp
+++ b/test/switch/flow_mock.cpp
@@ -16,4 +16,6 @@ std::shared_ptr<sim::IReceiver> FlowMock::get_receiver() const {
     return m_receiver;
 }
 
+Id FlowMock::get_id() const { return 42; }
+
 }  // namespace test

--- a/test/switch/flow_mock.hpp
+++ b/test/switch/flow_mock.hpp
@@ -16,6 +16,8 @@ public:
     std::shared_ptr<sim::ISender> get_sender() const final;
     std::shared_ptr<sim::IReceiver> get_receiver() const final;
 
+    Id get_id() const;
+
 private:
     std::shared_ptr<sim::IReceiver> m_receiver;
 };

--- a/test/switch/flow_mock.hpp
+++ b/test/switch/flow_mock.hpp
@@ -16,7 +16,7 @@ public:
     std::shared_ptr<sim::ISender> get_sender() const final;
     std::shared_ptr<sim::IReceiver> get_receiver() const final;
 
-    Id get_id() const;
+    Id get_id() const final;
 
 private:
     std::shared_ptr<sim::IReceiver> m_receiver;

--- a/test/switch/link_mock.cpp
+++ b/test/switch/link_mock.cpp
@@ -26,3 +26,5 @@ std::optional<sim::Packet> LinkMock::get_packet() { return m_ingress_packet; }
 std::vector<sim::Packet> LinkMock::get_arrived_packets() const {
     return m_arrived_packets;
 }
+
+Id LinkMock::get_id() const { return 42; }

--- a/test/switch/link_mock.hpp
+++ b/test/switch/link_mock.hpp
@@ -16,6 +16,8 @@ public:
     void set_ingress_packet(sim::Packet a_paket);
     std::vector<sim::Packet> get_arrived_packets() const;
 
+    Id get_id() const final;
+
 private:
     std::weak_ptr<sim::IRoutingDevice> m_from;
     std::weak_ptr<sim::IRoutingDevice> m_to;

--- a/test/switch/receiver_mock.cpp
+++ b/test/switch/receiver_mock.cpp
@@ -22,9 +22,7 @@ std::shared_ptr<sim::ILink> ReceiverMock::get_link_to_destination(
     return nullptr;
 }
 
-std::uint32_t ReceiverMock::process() {
-    return 1;
-}
+std::uint32_t ReceiverMock::process() { return 1; }
 sim::DeviceType ReceiverMock::get_type() const {
     return sim::DeviceType::RECEIVER;
 }
@@ -32,5 +30,7 @@ sim::DeviceType ReceiverMock::get_type() const {
 std::set<std::shared_ptr<sim::ILink>> ReceiverMock::get_outlinks() const {
     return {};
 }
+
+Id ReceiverMock::get_id() const { return 42; }
 
 }  // namespace test

--- a/test/switch/receiver_mock.hpp
+++ b/test/switch/receiver_mock.hpp
@@ -20,6 +20,8 @@ public:
 
     Time process() final;
     sim::DeviceType get_type() const final;
+
+    Id get_id() const final;
 };
 
 }  // namespace test


### PR DESCRIPTION
Closes #134 

`IdentifierFactory` is a singleton class that generates IDs.
`Identifiable` is an interface for entities with ID (devices, links, flows).