### PR TITLE
REFACTORING: Store time in scheduler

### DIFF
--- a/configuration_examples/simulation_examples/basic_simulation.yml
+++ b/configuration_examples/simulation_examples/basic_simulation.yml
@@ -6,11 +6,13 @@ flows:
     receiver_id: "receiver1"
     packet_size: 1024
     packet_interval: 100
+    number_of_packets: 100
   flow2:
     sender_id: "sender2"
     receiver_id: "receiver2"
     packet_size: 1024
     packet_interval: 100
+    number_of_packets: 100
 
 # No congestion control -- BasicSimulator
 algorithm: basic

--- a/configuration_examples/topology_examples/bus_topology.yml
+++ b/configuration_examples/topology_examples/bus_topology.yml
@@ -17,16 +17,36 @@ links:
     latency: 1ns
     throughput: 1Gbps
   link2:
+    from: bus
+    to: sender1
+    latency: 1ns
+    throughput: 1Gbps
+  link3:
     from: sender2
     to: bus
     latency: 1ns
     throughput: 1Gbps
-  link3:
+  link4:
+    from: bus
+    to: sender2
+    latency: 1ns
+    throughput: 1Gbps
+  link5:
+    from: receiver1
+    to: bus
+    latency: 1ns
+    throughput: 1Gbps
+  link6:
     from: bus
     to: receiver1
     latency: 1ns
     throughput: 1Gbps
-  link4:
+  link7:
+    from: receiver2
+    to: bus
+    latency: 1ns
+    throughput: 1Gbps
+  link8:
     from: bus
     to: receiver2
     latency: 1ns

--- a/source/link.cpp
+++ b/source/link.cpp
@@ -42,10 +42,8 @@ void Link::schedule_arrival(Packet packet) {
     LOG_INFO("Packet arrived to link's ingress queue. Packet: " + packet.to_string());
 
     unsigned int transmission_time = get_transmission_time(packet);
-    unsigned int total_delay = m_src_egress_delay + transmission_time;
-    (void) total_delay; // unused variable stub
-
     m_src_egress_delay += transmission_time;
+    unsigned int total_delay = Scheduler::get_instance().get_current_time() + m_src_egress_delay;
 
     // TODO: put correct event time. Arrive happens in current time + total_delay.
     Scheduler::get_instance().add(

--- a/source/parser.cpp
+++ b/source/parser.cpp
@@ -165,6 +165,7 @@ void YamlParser::process_flows(const YAML::Node &config) {
 
         Size packet_size = it->second["packet_size"].as<Size>();
         Time packet_interval = it->second["packet_interval"].as<Time>();
+        std::uint32_t number_of_packets = it->second["number_of_packets"].as<std::uint32_t>();
 
         std::shared_ptr<ISender> sender =
             std::dynamic_pointer_cast<ISender>(m_devices.at(sender_id));
@@ -173,7 +174,7 @@ void YamlParser::process_flows(const YAML::Node &config) {
 
         std::visit(
             [&](auto &sim) {
-                sim.add_flow(sender, receiver, packet_size, packet_interval, 0);
+                sim.add_flow(sender, receiver, packet_size, packet_interval, number_of_packets);
             },
             m_simulator);
     }

--- a/source/scheduler.cpp
+++ b/source/scheduler.cpp
@@ -15,6 +15,7 @@ bool Scheduler::tick() {
         std::move(const_cast<std::unique_ptr<Event>&>(m_events.top()));
     m_events.pop();
     event->operator()();
+    m_current_event_local_time = event->get_time();
     return true;
 }
 
@@ -27,5 +28,14 @@ void Scheduler::clear() {
                                    std::vector<std::unique_ptr<Event>>,
                                    EventComparator>();
 }
+
+Time Scheduler::get_current_time() {
+    return m_current_event_local_time;
+};
+
+Time Scheduler::increase_current_time(Time offset) {
+    m_current_event_local_time += offset;
+    return m_current_event_local_time;
+};
 
 }  // namespace sim

--- a/source/scheduler.hpp
+++ b/source/scheduler.hpp
@@ -27,6 +27,8 @@ public:
     void add(std::unique_ptr<Event> event);
     void clear();  // Clear all events
     bool tick();
+    Time get_current_time();
+    Time increase_current_time(Time offset);
 
 private:
     // Private constructor to prevent instantiation
@@ -38,6 +40,8 @@ private:
     std::priority_queue<std::unique_ptr<Event>,
                         std::vector<std::unique_ptr<Event>>, EventComparator>
         m_events;
+
+    Time m_current_event_local_time;
 };
 
 }  // namespace sim


### PR DESCRIPTION
1) Now it's possible to get and update time of current event
2) Fixed bug with incorrect link arrival time calculation
3) Fixed bug with 0 number of packets in flows by default