### PR TITLE
Removed put_data_to_device from flow interface

### DIFF
--- a/source/flow.cpp
+++ b/source/flow.cpp
@@ -19,21 +19,9 @@ Flow::Flow(std::shared_ptr<ISender> a_src, std::shared_ptr<IReceiver> a_dest,
       m_packets_to_send(a_packets_to_send),
       m_id(IdentifierFactory::get_instance().generate_id()) {}
 
-void Flow::schedule_packet_generation(Time time) {
-    auto generate_event_ptr =
-        Generate(time, shared_from_this(), m_packet_size);
-    Scheduler::get_instance().add(std::move(generate_event_ptr));
+void Flow::start() {
+    schedule_packet_generation(Scheduler::get_instance().get_current_time());
 }
-
-Packet Flow::generate_packet() {
-    sim::Packet packet;
-    packet.type = sim::PacketType::DATA;
-    packet.size_byte = m_packet_size;
-    packet.flow = this;
-    return packet;
-}
-
-void Flow::start() { schedule_packet_generation(Scheduler::get_instance().get_current_time()); }
 
 void Flow::update(Packet packet, DeviceType type) {
     (void)packet;
@@ -53,6 +41,12 @@ Time Flow::create_new_data_packet() {
     return put_data_to_device();
 }
 
+std::shared_ptr<ISender> Flow::get_sender() const { return m_src.lock(); }
+
+std::shared_ptr<IReceiver> Flow::get_receiver() const { return m_dest.lock(); }
+
+Id Flow::get_id() const { return m_id; }
+
 Time Flow::put_data_to_device() {
     if (m_src.expired()) {
         LOG_ERROR("Flow source was deleted; can not put data to it");
@@ -63,10 +57,17 @@ Time Flow::put_data_to_device() {
     return m_delay_between_packets;
 }
 
-std::shared_ptr<ISender> Flow::get_sender() const { return m_src.lock(); }
+void Flow::schedule_packet_generation(Time time) {
+    auto generate_event_ptr = Generate(time, shared_from_this(), m_packet_size);
+    Scheduler::get_instance().add(std::move(generate_event_ptr));
+}
 
-std::shared_ptr<IReceiver> Flow::get_receiver() const { return m_dest.lock(); }
-
-Id Flow::get_id() const { return m_id; }
+Packet Flow::generate_packet() {
+    sim::Packet packet;
+    packet.type = sim::PacketType::DATA;
+    packet.size_byte = m_packet_size;
+    packet.flow = this;
+    return packet;
+}
 
 }  // namespace sim

--- a/source/flow.hpp
+++ b/source/flow.hpp
@@ -14,10 +14,9 @@ class IFlow : public Identifiable {
 public:
     virtual void start() = 0;
     // Adds new packet to sending queue
-    // Used in event Generate
+    // This packet will be send at some time in future (depends on concrete
+    // flow) Used in event Generate
     virtual Time create_new_data_packet() = 0;
-    // Puts some pakets from sending buffer to sender's buffer according to the internal state
-    virtual Time put_data_to_device() = 0;
 
     // Update the internal state according to some congestion control algorithm
     // Calls when data available for sending on corresponding device
@@ -37,7 +36,6 @@ public:
     void start() final;
 
     Time create_new_data_packet() final;
-    Time put_data_to_device() final;
 
     // Update the internal state according to some congestion control algorithm
     // Call try_to_generate upon the update
@@ -50,6 +48,7 @@ public:
     Id get_id() const final;
 
 private:
+    Time put_data_to_device();
     void schedule_packet_generation(Time time);
     Packet generate_packet();
 

--- a/test/switch/flow_mock.cpp
+++ b/test/switch/flow_mock.cpp
@@ -6,19 +6,11 @@ FlowMock::FlowMock(std::shared_ptr<sim::IReceiver> m_receiver)
     : m_receiver(m_receiver) {}
 
 void FlowMock::start() {}
-Time FlowMock::create_new_data_packet() {
-    return 1;
-};
-Time FlowMock::put_data_to_device() {
-    return 1;
-};
+Time FlowMock::create_new_data_packet() { return 1; };
 
-void FlowMock::update(sim::Packet packet, sim::DeviceType type) {
-    
-};
-std::shared_ptr<sim::ISender> FlowMock::get_sender() const {
-    return nullptr;
-}
+void FlowMock::update(sim::Packet packet, sim::DeviceType type) {};
+
+std::shared_ptr<sim::ISender> FlowMock::get_sender() const { return nullptr; }
 std::shared_ptr<sim::IReceiver> FlowMock::get_receiver() const {
     return m_receiver.lock();
 }

--- a/test/switch/flow_mock.hpp
+++ b/test/switch/flow_mock.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include "flow.hpp"
 #include "device/sender.hpp"
+#include "flow.hpp"
 
 namespace test {
 
@@ -12,7 +12,6 @@ public:
     void start() final;
 
     Time create_new_data_packet() final;
-    Time put_data_to_device() final;
 
     void update(sim::Packet packet, sim::DeviceType type) final;
     std::uint32_t get_updates_number() const;


### PR DESCRIPTION
Deleted `put_data_to_device` from `IFlow` interface. Reason: we have method `create_data_packet` that creates packet that will be send in time choosen by flow, so there is no need to make method like `put_data_to_device` public