### PR TITLE
REFACTOR: Change RTT to a proper *round* trip time

### DIFF
--- a/source/device/receiver.cpp
+++ b/source/device/receiver.cpp
@@ -4,10 +4,10 @@
 
 #include "event.hpp"
 #include "link.hpp"
-#include "routing_module.hpp"
-#include "scheduling_module.hpp"
-#include "scheduler.hpp"
 #include "logger/logger.hpp"
+#include "routing_module.hpp"
+#include "scheduler.hpp"
+#include "scheduling_module.hpp"
 #include "utils/identifier_factory.hpp"
 #include "utils/validation.hpp"
 
@@ -29,7 +29,8 @@ bool Receiver::add_outlink(std::shared_ptr<ILink> link) {
     return m_router->add_outlink(link);
 }
 
-bool Receiver::update_routing_table(Id dest_id, std::shared_ptr<ILink> link, size_t paths_count) {
+bool Receiver::update_routing_table(Id dest_id, std::shared_ptr<ILink> link,
+                                    size_t paths_count) {
     if (!is_valid_link(link)) {
         return false;
     }
@@ -45,7 +46,8 @@ std::shared_ptr<ILink> Receiver::get_link_to_destination(Packet packet) const {
 };
 
 bool Receiver::notify_about_arrival(Time arrival_time) {
-    return m_process_scheduler.notify_about_arriving(arrival_time, weak_from_this());
+    return m_process_scheduler.notify_about_arriving(arrival_time,
+                                                     weak_from_this());
 };
 
 DeviceType Receiver::get_type() const { return DeviceType::RECEIVER; }
@@ -93,8 +95,9 @@ Time Receiver::process() {
         // TODO: think about redirecting time
     }
 
-
-    if (m_process_scheduler.notify_about_finish(Scheduler::get_instance().get_current_time() + total_processing_time)) {
+    if (m_process_scheduler.notify_about_finish(
+            Scheduler::get_instance().get_current_time() +
+            total_processing_time)) {
         return 0;
     }
 
@@ -103,9 +106,10 @@ Time Receiver::process() {
 
 Time Receiver::send_ack(Packet data_packet) {
     Time processing_time = 1;
-    Time current_time = Scheduler::get_instance().get_current_time();
-    Time RTT = data_packet.RTT + current_time -  data_packet.send_time;
-    Packet ack(PacketType::ACK, 1, data_packet.flow, data_packet.flow->get_receiver()->get_id(), data_packet.flow->get_sender()->get_id(), RTT, current_time);
+    // Note: ACK's sent time is the data packet sent time
+    Packet ack(PacketType::ACK, 1, data_packet.flow,
+               data_packet.flow->get_receiver()->get_id(),
+               data_packet.flow->get_sender()->get_id(), data_packet.sent_time);
 
     std::shared_ptr<ILink> link_to_dest = get_link_to_destination(ack);
     if (link_to_dest == nullptr) {

--- a/source/flow/flow.cpp
+++ b/source/flow/flow.cpp
@@ -41,8 +41,7 @@ Packet Flow::generate_packet() {
     packet.flow = this;
     packet.source_id = get_sender()->get_id();
     packet.dest_id = get_receiver()->get_id();
-    packet.RTT = 0;
-    packet.send_time = Scheduler::get_instance().get_current_time();
+    packet.sent_time = Scheduler::get_instance().get_current_time();
     return packet;
 }
 
@@ -54,9 +53,7 @@ void Flow::update(Packet packet, DeviceType type) {
 
     Time current_time = Scheduler::get_instance().get_current_time();
     MetricsCollector::get_instance().add_RTT(
-        packet.flow->get_id(),
-        current_time,
-        packet.RTT + current_time - packet.send_time);
+        packet.flow->get_id(), current_time, current_time - packet.sent_time);
 }
 
 std::uint32_t Flow::get_updates_number() const { return m_updates_number; }
@@ -82,7 +79,7 @@ Time Flow::put_data_to_device() {
         LOG_ERROR("Flow source was deleted; can not put data to it");
         return 0;
     }
-    m_sending_buffer.front().send_time =
+    m_sending_buffer.front().sent_time =
         Scheduler::get_instance().get_current_time();
     m_src.lock()->enqueue_packet(m_sending_buffer.front());
     m_sending_buffer.pop();

--- a/source/flow/tcp_flow.cpp
+++ b/source/flow/tcp_flow.cpp
@@ -66,13 +66,13 @@ void TcpFlow::update(Packet packet, DeviceType type) {
     }
 
     Time current_time = Scheduler::get_instance().get_current_time();
-    if (current_time < packet.send_time) {
+    if (current_time < packet.sent_time) {
         LOG_ERROR("Packet " + packet.to_string() +
                   " sending time less that current time; ignored");
         return;
     }
 
-    Time delay = packet.RTT + current_time - packet.send_time;
+    Time delay = current_time - packet.sent_time;
 
     LOG_INFO(fmt::format("Packet {} got in flow; delay = {}",
                          packet.to_string(), to_string(), delay));
@@ -130,8 +130,7 @@ Packet TcpFlow::generate_packet() {
     packet.flow = this;
     packet.source_id = get_sender()->get_id();
     packet.dest_id = get_receiver()->get_id();
-    packet.RTT = 0;
-    packet.send_time = Scheduler::get_instance().get_current_time();
+    packet.sent_time = Scheduler::get_instance().get_current_time();
     return packet;
 }
 

--- a/source/packet.cpp
+++ b/source/packet.cpp
@@ -1,25 +1,23 @@
 #include "packet.hpp"
 
-#include "device/sender.hpp"
-#include "device/receiver.hpp"
-
 #include <sstream>
 
+#include "device/receiver.hpp"
+#include "device/sender.hpp"
+
 namespace sim {
-Packet::Packet(PacketType a_type, Size a_size_byte, IFlow* a_flow, Id a_source_id, Id a_dest_id, Time a_RTT, Time a_send_time)
+Packet::Packet(PacketType a_type, Size a_size_byte, IFlow* a_flow,
+               Id a_source_id, Id a_dest_id, Time a_sent_time)
     : type(a_type),
       source_id(a_source_id),
       dest_id(a_dest_id),
-      RTT(a_RTT),
       size_byte(a_size_byte),
       flow(a_flow),
-      send_time(a_send_time) {}
+      sent_time(a_sent_time) {}
 
 bool Packet::operator==(const Packet& packet) const {
-    return flow == packet.flow && 
-           source_id == packet.source_id && 
-           dest_id == packet.dest_id &&
-           size_byte == packet.size_byte && 
+    return flow == packet.flow && source_id == packet.source_id &&
+           dest_id == packet.dest_id && size_byte == packet.size_byte &&
            type == packet.type;
 }
 
@@ -40,13 +38,13 @@ std::string Packet::to_string() const {
             oss << "UNKNOWN";
             break;
     }
-    
+
     oss << ", source_id: " << source_id;
     oss << ", dest_id: " << dest_id;
     oss << ", packet_num: " << packet_num;
     oss << ", size(byte): " << size_byte;
     oss << ", flow: " << (flow ? "set" : "null");
-    oss << ", send time: " << send_time;
+    oss << ", sent time: " << sent_time;
     oss << "]";
 
     return oss.str();

--- a/source/packet.hpp
+++ b/source/packet.hpp
@@ -13,7 +13,8 @@ enum PacketType { ACK, DATA };
 
 struct Packet {
     Packet(PacketType a_type = PacketType::DATA, Size a_size_byte = 0,
-           IFlow* a_flow = nullptr, Id a_source_id = "", Id a_dest_id = "", Time a_RTT = 0, Time a_send_time = 0);
+           IFlow* a_flow = nullptr, Id a_source_id = "", Id a_dest_id = "",
+           Time a_sent_time = 0);
 
     bool operator==(const Packet& packet) const;
     std::string to_string() const;
@@ -22,10 +23,9 @@ struct Packet {
     PacketType type;
     Id source_id;
     Id dest_id;
-    Time RTT;
     Size size_byte;
     IFlow* flow;
-    Time send_time;
+    Time sent_time;  // Note: ACK's sent time is the data packet sent time
 };
 
 }  // namespace sim


### PR DESCRIPTION
Closes #250. Packet class is refactored to notify of the sending time of the original data packet to calculate the full RTT.