### PR TITLE
BUG: compilation fails with clang

### DIFF
--- a/source/device/routing_module.cpp
+++ b/source/device/routing_module.cpp
@@ -9,15 +9,14 @@ namespace sim {
 
 RoutingModule::RoutingModule(Id a_id, std::unique_ptr<IHasher> a_hasher)
     : m_id(a_id),
-      m_hasher(std::move(a_hasher ? std::move(a_hasher) : std::make_unique<BaseHasher>())) {}
+      m_hasher(a_hasher ? std::move(a_hasher)
+                        : std::make_unique<BaseHasher>()) {}
 
-Id RoutingModule::get_id() const {
-    return m_id;
-}
+Id RoutingModule::get_id() const { return m_id; }
 
 bool RoutingModule::add_inlink(std::shared_ptr<ILink> link) {
     if (m_id != link->get_to()->get_id()) {
-       LOG_WARN(
+        LOG_WARN(
             "Link destination device is incorrect (expected current device)");
         return false;
     }
@@ -46,7 +45,9 @@ bool RoutingModule::add_outlink(std::shared_ptr<ILink> link) {
     return true;
 }
 
-bool RoutingModule::update_routing_table(Id dest_id, std::shared_ptr<ILink> link, size_t paths_count) {
+bool RoutingModule::update_routing_table(Id dest_id,
+                                         std::shared_ptr<ILink> link,
+                                         size_t paths_count) {
     if (m_id != link->get_from()->get_id()) {
         LOG_WARN("Link source device is incorrect (expected current device)");
         return false;
@@ -61,7 +62,8 @@ bool RoutingModule::update_routing_table(Id dest_id, std::shared_ptr<ILink> link
     return true;
 }
 
-std::shared_ptr<ILink> RoutingModule::get_link_to_destination(Packet packet) const {
+std::shared_ptr<ILink> RoutingModule::get_link_to_destination(
+    Packet packet) const {
     auto iterator = m_routing_table.find(packet.dest_id);
     if (iterator == m_routing_table.end()) {
         return nullptr;
@@ -125,9 +127,9 @@ void RoutingModule::correctify_outlinks() {
                   [](std::weak_ptr<ILink> link) { return link.expired(); });
 }
 
-bool RoutingModule::notify_about_arrival(Time arrival_time) { 
+bool RoutingModule::notify_about_arrival(Time arrival_time) {
     (void)arrival_time;
-    return false; 
+    return false;
 };
 
 }  // namespace sim

--- a/source/device/switch.cpp
+++ b/source/device/switch.cpp
@@ -11,7 +11,9 @@ namespace sim {
 Switch::Switch(Id a_id, bool a_ecn_capable_transport, double a_ecn_threshold)
     : m_ecn_capable_transport(a_ecn_capable_transport),
       m_ecn_threshold(a_ecn_threshold),
-      m_router(std::make_unique<RoutingModule>(a_id)) {}
+      m_router(std::make_unique<RoutingModule>(a_id)) {
+    (void)m_ecn_capable_transport;
+}
 
 bool Switch::add_inlink(std::shared_ptr<ILink> link) {
     if (!is_valid_link(link)) {

--- a/source/device/switch.cpp
+++ b/source/device/switch.cpp
@@ -11,9 +11,7 @@ namespace sim {
 Switch::Switch(Id a_id, bool a_ecn_capable_transport, double a_ecn_threshold)
     : m_ecn_capable_transport(a_ecn_capable_transport),
       m_ecn_threshold(a_ecn_threshold),
-      m_router(std::make_unique<RoutingModule>(a_id)) {
-    (void)m_ecn_capable_transport;
-}
+      m_router(std::make_unique<RoutingModule>(a_id)) {}
 
 bool Switch::add_inlink(std::shared_ptr<ILink> link) {
     if (!is_valid_link(link)) {
@@ -82,7 +80,8 @@ Time Switch::process() {
              packet.to_string());
 
     // ECN mark for data packets
-    if (packet.type == DATA && packet.ecn_capable_transport &&
+    if (m_ecn_capable_transport && packet.type == DATA &&
+        packet.ecn_capable_transport &&
         static_cast<double>(next_link->get_from_egress_queue_size()) >=
             m_ecn_threshold *
                 static_cast<double>(


### PR DESCRIPTION
Closes #243

Main changes:
- Remove redundant `std::move` in `RoutingModule` constructor
- Add correct usage of `Switch::m_ecn_capable_transport`