### PR TITLE
FEAT: Optional queue size limit line on plots

### DIFF
--- a/source/metrics/links_queue_size_storage.cpp
+++ b/source/metrics/links_queue_size_storage.cpp
@@ -46,7 +46,7 @@ static bool has_value_above_threshold(
     const std::vector<std::pair<sim::MetricsStorage, std::string>>& data,
     double threshold) {
     for (auto& [storage, _] : data) {
-        for (auto& [time, value] : storage.get_records()) {
+        for (auto& [_, value] : storage.get_records()) {
             if (value > threshold) {
                 return true;
             }

--- a/source/metrics/links_queue_size_storage.cpp
+++ b/source/metrics/links_queue_size_storage.cpp
@@ -100,6 +100,9 @@ void LinksQueueSizeStorage::draw_plots(
         }
 
         ax->xlim({0, limits[1]});
+        ax->ylim({0, static_cast<double>(std::max(
+                         link->get_max_from_egress_buffer_size().value(),
+                         link->get_max_to_ingress_queue_size().value()))});
         ax->color("white");
 
         std::filesystem::path plot_path =

--- a/source/metrics/links_queue_size_storage.cpp
+++ b/source/metrics/links_queue_size_storage.cpp
@@ -106,7 +106,6 @@ void LinksQueueSizeStorage::draw_plots(
 
         ax->xlim({0, limits[1]});
 
-
         ax->color("white");
 
         std::filesystem::path plot_path =
@@ -131,4 +130,3 @@ std::string LinksQueueSizeStorage::get_metrics_filename(Id id) const {
     return fmt::format("queue_size/{}.csv", id);
 }
 }  // namespace sim
-

--- a/source/metrics/links_queue_size_storage.cpp
+++ b/source/metrics/links_queue_size_storage.cpp
@@ -87,6 +87,8 @@ void LinksQueueSizeStorage::draw_plots(
                 .display_name(name);
         };
 
+        // Draw horizontal line for max queue size if there is value > 90% of
+        // max queue size
         if (has_value_above_threshold(
                 data, 0.9 * link->get_max_from_egress_buffer_size().value())) {
             draw_gorizontal_line(
@@ -100,9 +102,16 @@ void LinksQueueSizeStorage::draw_plots(
         }
 
         ax->xlim({0, limits[1]});
-        ax->ylim({0, static_cast<double>(std::max(
-                         link->get_max_from_egress_buffer_size().value(),
-                         link->get_max_to_ingress_queue_size().value()))});
+
+        double max_queue_size = static_cast<double>(
+            std::max(link->get_max_from_egress_buffer_size().value(),
+                     link->get_max_to_ingress_queue_size().value()));
+
+        // Set y-axis limit to 110% of the max queue size if it is less
+        if (double y_max = ax->ylim()[1]; y_max < max_queue_size) {
+            ax->ylim({0, max_queue_size * 1.1});
+        }
+
         ax->color("white");
 
         std::filesystem::path plot_path =

--- a/source/metrics/links_queue_size_storage.cpp
+++ b/source/metrics/links_queue_size_storage.cpp
@@ -87,16 +87,19 @@ void LinksQueueSizeStorage::draw_plots(
                 .display_name(name);
         };
 
-        // Draw horizontal line for max queue size if there is value > 90% of
+        // Draw horizontal line for max queue size if there is value > 30% of
         // max queue size
+        constexpr double MAX_SIZE_LINE_THRESHOLD = 0.3;
         if (has_value_above_threshold(
-                data, 0.9 * link->get_max_from_egress_buffer_size().value())) {
+                data, MAX_SIZE_LINE_THRESHOLD *
+                          link->get_max_from_egress_buffer_size().value())) {
             draw_gorizontal_line(
                 link->get_max_from_egress_buffer_size().value(),
                 "max from egress", {1.f, 0.f, 0.f});
         }
         if (has_value_above_threshold(
-                data, 0.9 * link->get_max_to_ingress_queue_size().value())) {
+                data, MAX_SIZE_LINE_THRESHOLD *
+                          link->get_max_to_ingress_queue_size().value())) {
             draw_gorizontal_line(link->get_max_to_ingress_queue_size().value(),
                                  "max to ingress", {0.f, 0.f, 1.f});
         }

--- a/source/metrics/links_queue_size_storage.cpp
+++ b/source/metrics/links_queue_size_storage.cpp
@@ -106,14 +106,6 @@ void LinksQueueSizeStorage::draw_plots(
 
         ax->xlim({0, limits[1]});
 
-        double max_queue_size = static_cast<double>(
-            std::max(link->get_max_from_egress_buffer_size().value(),
-                     link->get_max_to_ingress_queue_size().value()));
-
-        // Set y-axis limit to 110% of the max queue size if it is less
-        if (double y_max = ax->ylim()[1]; y_max < max_queue_size) {
-            ax->ylim({0, max_queue_size * 1.1});
-        }
 
         ax->color("white");
 

--- a/source/metrics/links_queue_size_storage.cpp
+++ b/source/metrics/links_queue_size_storage.cpp
@@ -131,3 +131,4 @@ std::string LinksQueueSizeStorage::get_metrics_filename(Id id) const {
     return fmt::format("queue_size/{}.csv", id);
 }
 }  // namespace sim
+

--- a/source/metrics/metrics_storage.cpp
+++ b/source/metrics/metrics_storage.cpp
@@ -55,7 +55,7 @@ void MetricsStorage::draw_on_plot(matplot::figure_handle& fig,
     std::transform(begin(m_records), end(m_records), std::back_inserter(y_data),
                    [](auto const& pair) { return pair.second; });
 
-    auto plot = fig->current_axes()->plot(x_data, y_data, "-");
+    auto plot = fig->current_axes()->plot(x_data, y_data, "-o");
     plot->line_width(1.5);
     plot->display_name(name);
 }

--- a/source/metrics/metrics_storage.cpp
+++ b/source/metrics/metrics_storage.cpp
@@ -55,7 +55,7 @@ void MetricsStorage::draw_on_plot(matplot::figure_handle& fig,
     std::transform(begin(m_records), end(m_records), std::back_inserter(y_data),
                    [](auto const& pair) { return pair.second; });
 
-    auto plot = fig->current_axes()->plot(x_data, y_data, "-o");
+    auto plot = fig->current_axes()->plot(x_data, y_data, "-");
     plot->line_width(1.5);
     plot->display_name(name);
 }


### PR DESCRIPTION
Closes #todo_issue 

Now max queue size line draws if there is a value > 0.9 * `link.max_queue_size`

Before and after:

<img width="2470" height="947" alt="image" src="https://github.com/user-attachments/assets/930c3067-752c-4627-aa38-23d43214acb4" />
