### PR TITLE
REFACTOR: eliminate long double

### DIFF
--- a/ds/test_queue.cpp
+++ b/ds/test_queue.cpp
@@ -78,7 +78,7 @@ void testDeQueueThrowsAnInvalidArgumentWhenQueueEmpty() {
 int main() {
     testConstructedQueueIsEmpty<int>();
     testConstructedQueueIsEmpty<double>();
-    testConstructedQueueIsEmpty<std::vector<long double>>();
+    testConstructedQueueIsEmpty<std::vector<double>>();
 
     testEnQueue();
     testDeQueue();

--- a/ds/test_stack.cpp
+++ b/ds/test_stack.cpp
@@ -158,7 +158,7 @@ void testAssign() {
 }
 
 void testTopThrowsAnInvalidArgumentWhenStackEmpty() {
-    const stack<long double> curStack;
+    const stack<double> curStack;
     bool wasException = false;
     try {
         curStack.top();

--- a/source/flow/tcp/swift/swift_cc.hpp
+++ b/source/flow/tcp/swift/swift_cc.hpp
@@ -31,11 +31,11 @@ public:
      * a_fs_min_cwnd      cwnd where flow‑scaling hits fs_range.
      * a_fs_max_cwnd      cwnd where flow‑scaling goes to zero.
      */
-    TcpSwiftCC(TimeNs a_base_target, long double a_additive_inc = 0.5L,
-               long double a_md_beta = 0.5L,  // from [0.2, 0.5] diapason
-               long double a_max_mdf = 0.3L, long double a_fs_range = 1.5L,
-               long double a_fs_min_cwnd = 0.1L,   // taken from the paper
-               long double a_fs_max_cwnd = 100.0L  // taken from the paper
+    TcpSwiftCC(TimeNs a_base_target, double a_additive_inc = 0.5,
+               double a_md_beta = 0.5,  // from [0.2, 0.5] diapason
+               double a_max_mdf = 0.3, double a_fs_range = 1.5,
+               double a_fs_min_cwnd = 0.1,  // taken from the paper
+               double a_fs_max_cwnd = 100.  // taken from the paper
     );
 
     void on_ack(TimeNs rtt, TimeNs avg_rtt, bool ecn_flag) final;
@@ -57,7 +57,7 @@ private:
     // Based on m_last_rtt
     [[nodiscard]] bool compute_can_decreace() const;
 
-    void update_cwnd(long double neww_cwnd);
+    void update_cwnd(double neww_cwnd);
 
     // ---------- Tunables ----------
     const TimeNs m_base_target;  // base RTT budget (ns)
@@ -66,23 +66,23 @@ private:
     const double m_max_mdf;      // cap on MD factor per RTT
 
     // Flow‑scaling parameters (cf. Swift §3.1)
-    const TimeNs m_fs_range_ns;       // scale range ns (base target * fs range)
-    const long double m_fs_min_cwnd;  // packets
-    const long double m_fs_max_cwnd;  // packets
-    TimeNs m_alpha_flow;              // flow scaling α, ns
-    TimeNs m_beta_flow;               // flow scaling β (runtime‑set), ns
+    const TimeNs m_fs_range_ns;  // scale range ns (base target * fs range)
+    const double m_fs_min_cwnd;  // packets
+    const double m_fs_max_cwnd;  // packets
+    TimeNs m_alpha_flow;         // flow scaling α, ns
+    TimeNs m_beta_flow;          // flow scaling β (runtime‑set), ns
                          // a positive value (unlike the article), as the
                          // internal TimeNs type is used (not negative)
     static constexpr std::size_t M_RETX_RESET_THRESHOLD = 3;
     // ---------- СС state ----------
-    long double m_cwnd;      // congestion window (packets)
+    double m_cwnd;           // congestion window (packets)
     TimeNs m_last_decrease;  // last MD timestamp
     TimeNs m_last_rtt;       // last sampled RTT
     std::size_t m_retransmit_cnt;
 
     // ----------- Limits -----------
-    static constexpr long double M_MIN_CWND = 0.001L;  // taken from the paper
-    static constexpr long double M_MAX_CWND = 1e6;
+    static constexpr double M_MIN_CWND = 0.001;  // taken from the paper
+    static constexpr double M_MAX_CWND = 1e6;
 };
 
 }  // namespace sim

--- a/source/flow/tcp/tcp_flow.cpp
+++ b/source/flow/tcp/tcp_flow.cpp
@@ -7,8 +7,9 @@ FlagManager<std::string, PacketFlagsBase> TcpFlow::m_flag_manager;
 bool TcpFlow::m_is_flag_manager_initialized = false;
 
 TcpFlow::TcpFlow(Id a_id, std::shared_ptr<IHost> a_src,
-        std::shared_ptr<IHost> a_dest, std::unique_ptr<ITcpCC> a_cc, SizeByte a_packet_size,
-        std::uint32_t a_packets_to_send, bool a_ecn_capable)
+                 std::shared_ptr<IHost> a_dest, std::unique_ptr<ITcpCC> a_cc,
+                 SizeByte a_packet_size, std::uint32_t a_packets_to_send,
+                 bool a_ecn_capable)
     : m_id(std::move(a_id)),
       m_src(a_src),
       m_dest(a_dest),
@@ -29,29 +30,19 @@ TcpFlow::TcpFlow(Id a_id, std::shared_ptr<IHost> a_src,
     initialize_flag_manager();
 }
 
-void TcpFlow::start() { 
-    send_packets(); 
+void TcpFlow::start() { send_packets(); }
+
+SizeByte TcpFlow::get_delivered_data_size() const {
+    return m_delivered_data_size;
 }
 
-SizeByte TcpFlow::get_delivered_data_size() const { 
-    return m_delivered_data_size; 
-}
+std::shared_ptr<IHost> TcpFlow::get_sender() const { return m_src.lock(); }
 
-std::shared_ptr<IHost> TcpFlow::get_sender() const { 
-    return m_src.lock(); 
-}
+std::shared_ptr<IHost> TcpFlow::get_receiver() const { return m_dest.lock(); }
 
-std::shared_ptr<IHost> TcpFlow::get_receiver() const { 
-    return m_dest.lock(); 
-}
+Id TcpFlow::get_id() const { return m_id; }
 
-Id TcpFlow::get_id() const { 
-    return m_id; 
-}
-
-SizeByte TcpFlow::get_delivered_bytes() const { 
-    return m_delivered_data_size; 
-}
+SizeByte TcpFlow::get_delivered_bytes() const { return m_delivered_data_size; }
 
 Packet TcpFlow::create_packet(PacketNum packet_num) {
     Packet packet;
@@ -66,9 +57,7 @@ Packet TcpFlow::create_packet(PacketNum packet_num) {
     return packet;
 }
 
-Packet TcpFlow::generate_packet() { 
-    return create_packet(m_next_packet_num++); 
-}
+Packet TcpFlow::generate_packet() { return create_packet(m_next_packet_num++); }
 
 void TcpFlow::initialize_flag_manager() {
     if (!m_is_flag_manager_initialized) {
@@ -80,10 +69,9 @@ void TcpFlow::initialize_flag_manager() {
 
 class TcpFlow::SendAtTime : public Event {
 public:
-    SendAtTime(TimeNs a_time, std::weak_ptr<TcpFlow> a_flow,
-               Packet a_packet)
+    SendAtTime(TimeNs a_time, std::weak_ptr<TcpFlow> a_flow, Packet a_packet)
         : Event(a_time), m_flow(a_flow), m_packet(std::move(a_packet)) {}
-    
+
     void operator()() final {
         if (m_flow.expired()) {
             LOG_ERROR("Pointer to flow expired");
@@ -128,7 +116,8 @@ private:
 };
 
 void TcpFlow::update(Packet packet) {
-    PacketType type =  static_cast<PacketType>(m_flag_manager.get_flag(packet, m_packet_type_label));
+    PacketType type = static_cast<PacketType>(
+        m_flag_manager.get_flag(packet, m_packet_type_label));
     if (packet.dest_id == m_src.lock()->get_id() && type == PacketType::ACK) {
         TimeNs current_time = Scheduler::get_instance().get_current_time();
         if (current_time < packet.sent_time) {
@@ -155,7 +144,7 @@ void TcpFlow::update(Packet packet) {
 
         double old_cwnd = m_cc->get_cwnd();
         m_cc->on_ack(rtt, m_rtt_statistics.get_mean(),
-                    packet.congestion_experienced);
+                     packet.congestion_experienced);
 
         m_delivered_data_size += m_packet_size;
 
@@ -167,16 +156,14 @@ void TcpFlow::update(Packet packet) {
 
         double cwnd = m_cc->get_cwnd();
         if (old_cwnd != cwnd) {
-            MetricsCollector::get_instance().add_cwnd(m_id, current_time,
-                                                      cwnd);
+            MetricsCollector::get_instance().add_cwnd(m_id, current_time, cwnd);
         }
     } else if (packet.dest_id == m_dest.lock()->get_id() &&
                type == PacketType::DATA) {
         Packet ack(SizeByte(1), this, m_dest.lock()->get_id(),
                    m_src.lock()->get_id(), packet.sent_time,
                    packet.delivered_data_size_at_origin,
-                   packet.ecn_capable_transport,
-                   packet.congestion_experienced);
+                   packet.ecn_capable_transport, packet.congestion_experienced);
         ack.packet_num = packet.packet_num;
         m_flag_manager.set_flag(ack, m_packet_type_label, PacketType::ACK);
         m_dest.lock()->enqueue_packet(ack);
@@ -203,7 +190,7 @@ TimeNs TcpFlow::get_max_timeout() const {
     TimeNs mean = m_rtt_statistics.get_mean();
     TimeNs std = m_rtt_statistics.get_std();
     if (mean == TimeNs(0)) {
-        return TimeNs(std::numeric_limits<long double>::max());
+        return TimeNs(std::numeric_limits<double>::max());
     }
     return mean * 2 + std * 4;
 }
@@ -212,7 +199,7 @@ void TcpFlow::send_packet_now(Packet packet) {
     TimeNs current_time = Scheduler::get_instance().get_current_time();
 
     TimeNs max_timeout = get_max_timeout();
-    if (max_timeout != TimeNs(std::numeric_limits<long double>::max())) {
+    if (max_timeout != TimeNs(std::numeric_limits<double>::max())) {
         Scheduler::get_instance().add<Timeout>(current_time + max_timeout,
                                                this->shared_from_this(),
                                                packet.packet_num);
@@ -235,9 +222,9 @@ void TcpFlow::send_packets() {
         if (pacing_delay == TimeNs(0)) {
             send_packet_now(std::move(packet));
         } else {
-            Scheduler::get_instance().add<SendAtTime>(
-                curr_time + total_delay, this->shared_from_this(),
-                std::move(packet));
+            Scheduler::get_instance().add<SendAtTime>(curr_time + total_delay,
+                                                      this->shared_from_this(),
+                                                      std::move(packet));
         }
         m_packets_in_flight++;
         m_packets_to_send--;

--- a/source/units/ld_comparation.hpp
+++ b/source/units/ld_comparation.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <cmath>
 
-constexpr bool equal(long double value_1, long double value_2) {
-    constexpr long double EPS = 1e-6;
+constexpr bool equal(double value_1, double value_2) {
+    constexpr double EPS = 1e-6;
     return std::abs(value_1 - value_2) < EPS;
 }

--- a/source/units/speed.hpp
+++ b/source/units/speed.hpp
@@ -9,7 +9,7 @@ private:
 
 public:
     // Attention: value given in TSizeBase per TTimeBase units!
-    constexpr explicit Speed(long double value)
+    constexpr explicit Speed(double value)
         : m_value_bit_per_ns(value * TSizeBase::to_bit_multiplier /
                              TTimeBase::to_nanoseconds_multiplier) {}
 
@@ -17,14 +17,12 @@ public:
     constexpr Speed(Speed<USizeBase, UTimeBase> speed)
         : m_value_bit_per_ns(speed.value_bit_per_ns()) {}
 
-    constexpr long double value() const {
+    constexpr double value() const {
         return m_value_bit_per_ns / TSizeBase::to_bit_multiplier *
                TTimeBase::to_nanoseconds_multiplier;
     }
 
-    constexpr long double value_bit_per_ns() const {
-        return m_value_bit_per_ns;
-    }
+    constexpr double value_bit_per_ns() const { return m_value_bit_per_ns; }
 
     constexpr ThisSpeed operator+(ThisSpeed speed) const {
         return Speed<Bit, Nanosecond>(m_value_bit_per_ns +
@@ -36,11 +34,11 @@ public:
                                       speed.m_value_bit_per_ns);
     }
 
-    constexpr ThisSpeed operator*(long double mult) const {
+    constexpr ThisSpeed operator*(double mult) const {
         return Speed<Bit, Nanosecond>(m_value_bit_per_ns * mult);
     }
 
-    constexpr long double operator/(ThisSpeed speed) const {
+    constexpr double operator/(ThisSpeed speed) const {
         return m_value_bit_per_ns / speed.value_bit_per_ns();
     }
 
@@ -51,9 +49,9 @@ public:
         m_value_bit_per_ns -= speed.m_value_bit_per_ns;
     }
 
-    constexpr void operator*=(long double mult) { m_value_bit_per_ns *= mult; }
+    constexpr void operator*=(double mult) { m_value_bit_per_ns *= mult; }
 
-    constexpr void operator/=(long double mult) { m_value_bit_per_ns /= mult; }
+    constexpr void operator/=(double mult) { m_value_bit_per_ns /= mult; }
 
     bool constexpr operator<(ThisSpeed speed) const {
         return m_value_bit_per_ns < speed.m_value_bit_per_ns;
@@ -72,7 +70,7 @@ public:
     }
 
 private:
-    long double m_value_bit_per_ns;  // value in bit per nanosecond
+    double m_value_bit_per_ns;  // value in bit per nanosecond
 };
 
 template <IsSizeBase TSizeBase, IsTimeBase TTimeBase>

--- a/source/units/time.hpp
+++ b/source/units/time.hpp
@@ -34,24 +34,23 @@ class Time {
 public:
     using ThisTime = Time<TTimeBase>;
 
-    constexpr Time() : m_value_ns(0.0L) {}
+    constexpr Time() : m_value_ns(0.0) {}
     template <IsTimeBase USizeBase>
     constexpr Time(Time<USizeBase> a_size)
         : m_value_ns(a_size.value_nanoseconds()) {}
 
     // Attention: a_value given in TTimeBase units!
-    explicit constexpr Time(long double a_value)
+    explicit constexpr Time(double a_value)
         : m_value_ns(a_value * TTimeBase::to_nanoseconds_multiplier) {}
 
-
-    constexpr long double value() const {
+    constexpr double value() const {
         // Round up here to get maximal time
         return m_value_ns / TTimeBase::to_nanoseconds_multiplier;
     }
 
-    explicit constexpr operator long double() const { return value(); }
+    explicit constexpr operator double() const { return value(); }
 
-    constexpr long double value_nanoseconds() const { return m_value_ns; }
+    constexpr double value_nanoseconds() const { return m_value_ns; }
 
     constexpr ThisTime operator+(ThisTime time) const {
         return Time<Nanosecond>(m_value_ns + time.m_value_ns);
@@ -61,7 +60,7 @@ public:
         return Time<Nanosecond>(m_value_ns - time.m_value_ns);
     }
 
-    constexpr ThisTime operator*(long double mult) const {
+    constexpr ThisTime operator*(double mult) const {
         return Time<Nanosecond>(m_value_ns * mult);
     }
 
@@ -70,20 +69,20 @@ public:
         return *this;
     }
 
-    constexpr long double operator/(ThisTime time) const {
+    constexpr double operator/(ThisTime time) const {
         return m_value_ns / time.value_nanoseconds();
     }
 
-    constexpr ThisTime operator/(long double value) const {
+    constexpr ThisTime operator/(double value) const {
         return Time<Nanosecond>(m_value_ns / value);
     }
 
     constexpr void operator+=(ThisTime time) { m_value_ns += time.m_value_ns; }
     constexpr void operator-=(ThisTime time) { m_value_ns -= time.m_value_ns; }
 
-    constexpr void operator*=(long double mult) { m_value_ns *= mult; }
+    constexpr void operator*=(double mult) { m_value_ns *= mult; }
 
-    constexpr void operator/=(long double mult) { m_value_ns /= mult; }
+    constexpr void operator/=(double mult) { m_value_ns /= mult; }
 
     bool constexpr operator<(ThisTime time) const {
         return m_value_ns < time.m_value_ns;
@@ -100,7 +99,7 @@ public:
     bool constexpr operator!=(ThisTime time) const { return !operator==(time); }
 
 private:
-    long double m_value_ns;  // Time in nanoseconds
+    double m_value_ns;  // Time in nanoseconds
 };
 
 template <IsTimeBase TTimeBase>

--- a/source/utils/statistics.hpp
+++ b/source/utils/statistics.hpp
@@ -13,10 +13,10 @@ template <typename T, typename U>
 concept ExplicitlyConvertable = requires(T t) { static_cast<U>(t); };
 
 template <typename T>
-requires ExplicitlyConvertable<T, long double>
+requires ExplicitlyConvertable<T, double>
 class Statistics {
 public:
-    explicit Statistics(long double a_factor)
+    explicit Statistics(double a_factor)
         : m_factor(a_factor), m_mean(0), m_variance(0) {
         if (m_factor < 0 || m_factor > 1) {
             LOG_ERROR(
@@ -27,12 +27,12 @@ public:
     }
 
     void add_record(const T& record) {
-        long double value = static_cast<long double>(record);
+        double value = static_cast<double>(record);
         if (m_mean == 0 && m_variance == 0) {
             // first record
             m_mean = value;
         } else {
-            long double delta = value - m_mean;
+            double delta = value - m_mean;
             m_mean = m_mean * m_factor + value * (1 - m_factor);
             m_variance =
                 m_variance * m_factor + (delta * delta) * (1 - m_factor);
@@ -41,14 +41,14 @@ public:
 
     T get_mean() const { return T(m_mean); }
 
-    long double get_variance() { return m_variance; }
+    double get_variance() { return m_variance; }
 
     T get_std() const { return T(std::sqrt(m_variance)); }
 
 private:
-    const long double m_factor;
-    long double m_mean;
-    long double m_variance;
+    const double m_factor;
+    double m_mean;
+    double m_variance;
 };
 
 }  // namespace utils


### PR DESCRIPTION
No need to use `long double` -- this is a huge overkill. Floating point type `double` is far than sufficient for our purpose (even `float` could be fine, but `double` is a gold standard for most purposes).