### PR TITLE
BUG: Fix delivery rate

### DIFF
--- a/source/flow/tcp/tcp_flow.hpp
+++ b/source/flow/tcp/tcp_flow.hpp
@@ -48,7 +48,7 @@ private:
     class SendAtTime;
     class Timeout;
 
-    Packet create_packet(PacketNum packet_num);
+    Packet generate_data_packet(PacketNum packet_num);
     Packet create_ack(Packet data);
     Packet generate_packet();
 


### PR DESCRIPTION
In one of previous PRs `packet.delivered_time` used for calculating delivery rate was forgotten to set