### PR TITLE
FEAT: improve units

### DIFF
--- a/source/units/size.hpp
+++ b/source/units/size.hpp
@@ -114,6 +114,11 @@ private:
 };
 
 template <IsSizeBase TSizeBase>
+constexpr Size<TSizeBase> operator*(size_t mult, Size<TSizeBase> size) {
+    return size * mult;
+}
+
+template <IsSizeBase TSizeBase>
 std::ostream& operator<<(std::ostream& out, Size<TSizeBase> size) {
     return out << size.value();
 }

--- a/source/units/speed.hpp
+++ b/source/units/speed.hpp
@@ -76,6 +76,12 @@ private:
 };
 
 template <IsSizeBase TSizeBase, IsTimeBase TTimeBase>
+constexpr Speed<TSizeBase, TTimeBase> operator*(
+    size_t mult, Speed<TSizeBase, TTimeBase> speed) {
+    return speed * mult;
+}
+
+template <IsSizeBase TSizeBase, IsTimeBase TTimeBase>
 std::ostream& operator<<(std::ostream& out, Speed<TSizeBase, TTimeBase> speed) {
     return out << speed.value();
 }

--- a/source/units/time.hpp
+++ b/source/units/time.hpp
@@ -103,6 +103,11 @@ private:
 };
 
 template <IsTimeBase TTimeBase>
+Time<TTimeBase> operator*(double mult, Time<TTimeBase> time) {
+    return time * mult;
+}
+
+template <IsTimeBase TTimeBase>
 std::ostream& operator<<(std::ostream& out, Time<TTimeBase> time) {
     return out << time.value();
 }


### PR DESCRIPTION
Needs to add `operator*(multiplier, unit)` for each unit (now available only `operator*(unit, multiplier)`